### PR TITLE
removal of duplicate line from platform-unix.c 

### DIFF
--- a/PMAP-unix/platform-unix.c
+++ b/PMAP-unix/platform-unix.c
@@ -246,7 +246,6 @@ void PlatShowMessageB(const char *format, ...)
     // Print to standard output
     va_start(args, format);
     vprintf(format, args);
-    vprintf(format, args);
     va_end(args); // Clean up after using args for vprintf
 
     // Print to debug output file, if specified

--- a/base/elect.c
+++ b/base/elect.c
@@ -1309,7 +1309,7 @@ static int ElectJudgeCDTPP(const char *data, int len)
 
         if (Tbal >= -30 && Tbal <= 30)
         {
-            PlatDPrintf("CD TPP Tbal  OK: %ld\n", Tbal);
+            PlatDPrintf("CD TPP Tbal  OK: %d\n", Tbal);
             return 0;
         }
         else

--- a/base/elect.c
+++ b/base/elect.c
@@ -1314,7 +1314,7 @@ static int ElectJudgeCDTPP(const char *data, int len)
         }
         else
         {
-            PlatShowEMessage("CD TPP Tbal NG: %ld\n", Tbal);
+            PlatShowEMessage("CD TPP Tbal NG: %d\n", Tbal);
             return (ConSlim == 1) ? 0 : 1;
         }
     }


### PR DESCRIPTION
-removal of duplicate line from platform-unix.c, causing some messages to appear twice on macos
-fix Tbal print to log